### PR TITLE
feat(25): 이력/활동 카드 전체 조회

### DIFF
--- a/src/modules/cards/cards.controller.js
+++ b/src/modules/cards/cards.controller.js
@@ -92,6 +92,34 @@ const cardsController = {
             next(error)
         }
     },
+
+    getCardgrid: async (req, res, next) => {
+        try {
+            const { cursor, area, status, hope_job, keywords } = req.query
+
+            const result = await cardsService.getCardgrid({
+                cursor: cursor ? parseInt(cursor) : undefined,
+                area,
+                status,
+                hope_job,
+                // 키워드는 무조건 배열 형태로 변환
+                keywords: Array.isArray(keywords)
+                    ? keywords
+                    : keywords
+                      ? [keywords]
+                      : [],
+            })
+
+            res.success({
+                code: 200,
+                message: '카드 전체 보기 조회 성공',
+                result,
+            })
+        } catch (error) {
+            console.log('카드 전체 보기 중 에러 발생')
+            next(error)
+        }
+    },
 }
 
 export default cardsController

--- a/src/modules/cards/cards.routes.js
+++ b/src/modules/cards/cards.routes.js
@@ -187,6 +187,95 @@ router.get('/swipe', cardsController.getFilteredCards)
 
 /**
  * @swagger
+ * /api/cards/grid:
+ *   get:
+ *     summary: 전체보기 카드 리스트 조회 (무한 스크롤)
+ *     description: 최신순으로 전체 이력/활동 카드 이미지를 조회합니다. 한 번에 최대 10개씩 불러오며, next_cursor를 기반으로 다음 데이터를 요청할 수 있습니다.
+ *     tags:
+ *       - Cards
+ *     parameters:
+ *       - in: query
+ *         name: cursor
+ *         schema:
+ *           type: integer
+ *         required: false
+ *         description: 이전 요청에서 받은 next_cursor 값
+ *       - in: query
+ *         name: area
+ *         schema:
+ *           type: integer
+ *         required: false
+ *         description: "활동 지역 ID (예시: 1)"
+ *       - in: query
+ *         name: status
+ *         schema:
+ *           type: string
+ *         required: false
+ *         description: "활동 상태 (예시: 이직 준비 중)"
+ *       - in: query
+ *         name: hope_job
+ *         schema:
+ *           type: string
+ *         required: false
+ *         description: "희망 직무 (예시: 프론트엔드 개발)"
+ *       - in: query
+ *         name: keywords
+ *         schema:
+ *           type: array
+ *           items:
+ *             type: string
+ *         required: false
+ *         style: form
+ *         explode: true
+ *         description: 키워드 목록 예시 keywords=사이드프로젝트&keywords=인턴경험
+ *     responses:
+ *       200:
+ *         description: 카드 전체 보기 조회 성공
+ *         content:
+ *           application/json:
+ *             example:
+ *               isSuccess: true
+ *               code: 200
+ *               message: 카드 전체 보기 조회 성공
+ *               result:
+ *                 cards:
+ *                   - card_id: 23
+ *                     image_url: https://myfit.com/cards/23.jpg
+ *                   - card_id: 3
+ *                     image_url: https://myfit.com/cards/3.jpg
+ *                 total_count: 2
+ *                 next_cursor: null
+ *                 has_next: false
+ *       400:
+ *         description: 잘못된 요청입니다. 입력값을 확인해주세요.
+ *         content:
+ *           application/json:
+ *             example:
+ *               isSuccess: false
+ *               code: 400
+ *               message: 잘못된 요청입니다. 입력값을 확인해주세요.
+ *               result:
+ *                 errorCode: C001
+ *                 data:
+ *                   message: 잘못된 쿼리 파라미터가 포함되어 있습니다
+ *       500:
+ *         description: 서버에 오류가 발생하였습니다.
+ *         content:
+ *           application/json:
+ *             example:
+ *               isSuccess: false
+ *               code: 500
+ *               message: 서버에 오류가 발생하였습니다.
+ *               result:
+ *                 errorCode: S001
+ *                 data:
+ *                   message: 서버에 오류가 발생하였습니다.
+ */
+
+router.get('/grid', cardsController.getCardgrid)
+
+/**
+ * @swagger
  * /api/cards/{card_id}:
  *   get:
  *     summary: 이력/활동 카드 상세 조회


### PR DESCRIPTION
## 🔎 작업 내용

- 이력/활동 카드 전체 조회 API 구현

  <br/>

## 이미지 첨부

<img width="924" height="893" alt="Image" src="https://github.com/user-attachments/assets/025ae8fb-8cff-46e3-88e6-6e8c8193caa7" />

<br/>

## ➕ 이슈 링크

- [feature/25-get_activity_card_grid #25 ]
<br/>