### PR TITLE
 feat(40): 유저의 현재 구인/구직 상태 업데이트

### DIFF
--- a/src/modules/mypage/mypage.controller.js
+++ b/src/modules/mypage/mypage.controller.js
@@ -73,7 +73,41 @@ class MypageController {
             console.error('사용자 프로필 사진 업데이트 중 오류:', error);
             next(error);
         }
-    } 
+    }
+    
+    // PUT /api/mypage/:userId/recruiting_status 요청을 처리하여 사용자 서비스의 recruiting_status를 업데이트
+    static async updateRecruitingStatus(req, res, next) {
+        try {
+            const { userId } = req.params;
+            const { recruiting_status } = req.body;
+            const authenticatedUserId = req.user.service_id; 
+
+            // 1. 입력값 유효성 검사
+            if (!userId || isNaN(userId) || String(BigInt(userId)) !== userId) {
+                throw new BadRequestError({ field: 'userId', message: '유효한 사용자 ID가 필요합니다.' });
+            }
+            if (!recruiting_status || typeof recruiting_status !== 'string' || recruiting_status.trim() === '') {
+                throw new BadRequestError({ field: 'recruiting_status', message: '유효한 모집 상태 값이 필요합니다.' });
+            }
+
+            // 2. 권한 확인: 요청된 userId와 인증된 ID 일치 여부
+            if (String(authenticatedUserId) !== String(userId)) {
+                throw new ForbiddenError({ message: '수정할 수 있는 권한이 없습니다.' });
+            }
+
+            // 3. 서비스 호출
+            const result = await MypageService.updateRecruitingStatus(userId, recruiting_status);
+
+            return res.success({
+                code: 200,
+                message: '서비스 모집 상태가 성공적으로 수정되었습니다.',
+                result: result, 
+            });
+        } catch (error) {
+            next(error);
+        }
+    }
+    
 }
 
 export default MypageController;

--- a/src/modules/mypage/mypage.routes.js
+++ b/src/modules/mypage/mypage.routes.js
@@ -248,4 +248,109 @@ router.get('/:userId/profile_info', MypageController.getUserProfileInfo);
  */
 router.patch('/:userId/profile_pic', isAuthenticated, MypageController.updateProfilePicture);
 
+/**
+ * @swagger
+ * /api/mypage/{user_id}/recruiting_status:
+ *   patch:
+ *     summary: 유저의 현재 구인/구직 상태 업데이트
+ *     description: 로그인된 사용자와 연결된 서비스의 recruiting_status 를 업데이트합니다.
+ *     tags:
+ *       - Mypage
+ *     security:
+ *       - cookieAuth: [] # 쿠키 기반 인증을 사용함을 나타냄
+ *     parameters:
+ *       - in: path
+ *         name: user_id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: int64
+ *         description: recruiting_status를 업데이트할 사용자의 고유 ID
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - recruiting_status
+ *             properties:
+ *               recruiting_status:
+ *                 type: string
+ *                 enum: ['구직 중', '구인 중', '구인 협의 중', '네트워킹 환영', '해당 없음']
+ *                 example: "구직 중"
+ *     responses:
+ *       200:
+ *         description: 유저의 현재 구인/구직 상태 업데이트 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 isSuccess:
+ *                   type: boolean
+ *                   example: true
+ *                 code:
+ *                   type: number
+ *                   example: 200
+ *                 message:
+ *                   type: string
+ *                   example: 유저의 현재 구인/구직 상태가 성공적으로 수정되었습니다.
+ *                 result:
+ *                   type: object
+ *                   properties:
+ *                     user_id:
+ *                       type: string
+ *                       example: "1234567890123456789"
+ *                     service_id:
+ *                       type: string
+ *                       example: "9876543210987654321"
+ *                     recruiting_status:
+ *                       type: string
+ *                       example: "구직 중"
+ *       400:
+ *         description: 잘못된 요청 (유효하지 않은 입력값 또는 상태 값)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/BadRequestError'
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "유효한 모집 상태 값이 필요합니다."
+ *       401:
+ *         description: 인증되지 않은 요청 (로그인 필요)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/UnauthorizedError'
+ *       403:
+ *         description: 권한 없음 (다른 사용자의 현재 구인/구직 상태 수정 시도)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ForbiddenError'
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "권한이 없습니다. 자신의 현재 상태만 수정할 수 있습니다."
+ *       404:
+ *         description: 사용자를 찾을 수 없거나 연결된 서비스를 찾을 수 없습니다.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/NotFoundError'
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "해당 사용자와 연결된 서비스를 찾을 수 없습니다."
+ *       500:
+ *         description: 서버 오류
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/InternalServerError'
+ */
+router.patch('/:userId/recruiting_status', isAuthenticated, MypageController.updateRecruitingStatus);
+
 export default router;

--- a/src/modules/mypage/mypage.service.js
+++ b/src/modules/mypage/mypage.service.js
@@ -1,5 +1,5 @@
 import MypageModel from './mypage.model.js';
-import { NotFoundError, InternalServerError, CustomError } from '../../middlewares/error.js';
+import { NotFoundError, InternalServerError, BadRequestError, CustomError } from '../../middlewares/error.js';
 
 class MypageService {
     /**
@@ -66,6 +66,54 @@ class MypageService {
                 throw new NotFoundError('사용자를 찾을 수 없습니다.');
             }
             throw new InternalServerError({ message: '프로필 사진을 수정하는 중 서버 오류가 발생했습니다.', originalError: error.message });
+        }
+    }
+
+    /**
+     * 서비스의 recruiting_status를 업데이트
+     * @param {string} userId  
+     * @param {string} newStatus - 업데이트할 새로운 상태 값
+     * @returns {Promise<Object>} 업데이트된 서비스 정보
+     * @throws {NotFoundError} 
+     * @throws {BadRequestError} 
+     * @throws {InternalServerError} 
+     */
+    static async updateRecruitingStatus(userId, newStatus) {
+        // 허용되는 recruiting_status 값 목록 
+        const ALLOWED_STATUSES = ['구직 중', '구인 중', '구인 협의 중', '네트워킹 환영', '해당 없음']; 
+
+        try {
+            // 1. 유효성 검사: newStatus가 허용되는 값인지 확인
+            if (!ALLOWED_STATUSES.includes(newStatus)) { // 대소문자 구분 없이 처리
+                throw new BadRequestError({ message: `'${newStatus}'은(는) 유효하지 않은 모집 상태 값입니다. 허용되는 값: ${ALLOWED_STATUSES.join(', ')}` });
+            }
+
+            // 2. 사용자 존재 여부 확인
+            const existingUser = await MypageModel.findUserProfileById(BigInt(userId));
+            if (!existingUser) {
+                throw new NotFoundError('해당 사용자를 찾을 수 없습니다.');
+            }
+
+            // 3. 모델 계층 호출하여 recruiting_status 업데이트
+            const updatedServiceResult = await MypageModel.updateRecruitingStatus(BigInt(userId), newStatus);
+
+            // 연결된 서비스가 없어서 업데이트가 이루어지지 않은 경우
+            if (!updatedServiceResult) {
+                throw new NotFoundError('해당 사용자와 연결된 서비스를 찾을 수 없습니다.');
+            }
+
+            // 모델에서 반환된 값을 그대로 반환
+            return updatedServiceResult;
+
+        } catch (error) {
+            console.error('MypageService - 모집 상태 업데이트 서비스 오류:', error);
+            if (error instanceof CustomError) {
+                throw error;
+            }
+            if (error.code === 'P2025') { 
+                throw new NotFoundError('서비스를 찾을 수 없습니다.'); 
+            }
+            throw new InternalServerError({ message: '유저 상태를 수정하는 중 서버 오류가 발생했습니다.', originalError: error.message });
         }
     }
 }


### PR DESCRIPTION
- 제목 : feat(40): 유저의 현재 구인/구직 상태 업데이트

## 🔎 작업 내용

- 작업 내용 1: /api/mypage/{user_id}/recruiting_status api 구현

  <br/>

## 이미지 첨부

<img width="2131" height="998" alt="스크린샷 2025-07-18 102852" src="https://github.com/user-attachments/assets/2cf7d2ee-a841-4f82-8517-02b901eaab43" />
<img width="2128" height="1251" alt="스크린샷 2025-07-18 102838" src="https://github.com/user-attachments/assets/b6510356-3213-4021-9ae1-9602a8eaf8ec" />
<img width="2117" height="1106" alt="스크린샷 2025-07-18 102821" src="https://github.com/user-attachments/assets/164ccb34-ee9a-4b1c-86e4-11550e0338c0" />
<img width="2142" height="1290" alt="스크린샷 2025-07-18 102800" src="https://github.com/user-attachments/assets/31f6d349-0561-470a-81ef-65252a53992b" />


<br/>

## ➕ 이슈 링크

- [feature/40-update-recruiting-status  #36 ]

<br/>