### PR TITLE
prisma - Network모델 수정, UserBlock 모델 추가

### DIFF
--- a/prisma/migrations/20250719112422_network_status_and_user_block_update/migration.sql
+++ b/prisma/migrations/20250719112422_network_status_and_user_block_update/migration.sql
@@ -1,0 +1,43 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `is_mutual` on the `Network` table. All the data in the column will be lost.
+  - Added the required column `updated_at` to the `Network` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE `Network` DROP COLUMN `is_mutual`,
+    ADD COLUMN `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    ADD COLUMN `status` ENUM('PENDING', 'ACCEPTED', 'REJECTED') NOT NULL DEFAULT 'PENDING',
+    ADD COLUMN `updated_at` DATETIME(3) NOT NULL;
+
+-- CreateTable
+CREATE TABLE `UserBlock` (
+    `id` BIGINT NOT NULL AUTO_INCREMENT,
+    `blocker_id` BIGINT NOT NULL,
+    `blocked_id` BIGINT NOT NULL,
+    `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    INDEX `UserBlock_blocker_id_idx`(`blocker_id`),
+    INDEX `UserBlock_blocked_id_idx`(`blocked_id`),
+    UNIQUE INDEX `UserBlock_blocker_id_blocked_id_key`(`blocker_id`, `blocked_id`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateIndex
+CREATE INDEX `Network_sender_id_idx` ON `Network`(`sender_id`);
+
+-- CreateIndex
+CREATE INDEX `Network_sender_id_recipient_id_idx` ON `Network`(`sender_id`, `recipient_id`);
+
+-- CreateIndex
+CREATE INDEX `Network_recipient_id_sender_id_idx` ON `Network`(`recipient_id`, `sender_id`);
+
+-- AddForeignKey
+ALTER TABLE `UserBlock` ADD CONSTRAINT `UserBlock_blocker_id_fkey` FOREIGN KEY (`blocker_id`) REFERENCES `Service`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `UserBlock` ADD CONSTRAINT `UserBlock_blocked_id_fkey` FOREIGN KEY (`blocked_id`) REFERENCES `Service`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- RenameIndex
+-- ALTER TABLE `Network` RENAME INDEX `Network_recipient_id_fkey` TO `Network_recipient_id_idx`;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -66,6 +66,9 @@ model Service {
 
   requestedChats CoffeeChat[] @relation("RequestedChats")
   receivedChats  CoffeeChat[] @relation("ReceivedChats")
+
+  blockedOthers UserBlock[] @relation("BlockedBy")
+  blockedByOthers UserBlock[] @relation("Blocked")
 }
 
 model UserDB {
@@ -262,15 +265,46 @@ model Interest {
 
 model Network {
   id           BigInt  @id @default(autoincrement()) // 네트워크 번호 (PK)
-  is_mutual    Boolean @default(false) // 맞팔로우 여부
   sender_id    BigInt // 송신자 서비스 ID (FK)
   recipient_id BigInt // 수신자 서비스 ID (FK)
+  status NetworkStatus @default(PENDING) // 현재 네트워크 관계의 상태 (PENDING, ACCEPTED, REJECTED)
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
 
   // 관계
   sender    Service @relation("NetworkSender", fields: [sender_id], references: [id])
   recipient Service @relation("NetworkRecipient", fields: [recipient_id], references: [id])
 
   @@unique([sender_id, recipient_id], name: "unique_network_pair")
+  // 조회 성능을 위한 인덱스 추가
+  @@index([sender_id])
+  @@index([recipient_id])
+  @@index([sender_id, recipient_id])
+  @@index([recipient_id, sender_id])
+}
+
+enum NetworkStatus {
+  PENDING // 신청 대기 중
+  ACCEPTED // 신청 수락됨
+  REJECTED // 신청 거절됨
+}
+
+model UserBlock {
+  id        BigInt   @id @default(autoincrement())
+  blocker_id BigInt // 차단하는 사용자 ID
+  blocked_id BigInt // 차단당한 사용자 ID
+
+  // 관계 정의
+  blocker   Service @relation("BlockedBy", fields: [blocker_id], references: [id])
+  blocked   Service @relation("Blocked", fields: [blocked_id], references: [id])
+
+  createdAt DateTime @default(now()) @map("created_at")
+
+  @@unique([blocker_id, blocked_id], name: "unique_user_block")
+  // 조회 성능을 위한 인덱스
+  @@index([blocker_id])
+  @@index([blocked_id])
 }
 
 model ChattingRoom {


### PR DESCRIPTION
- 제목 : 프리즈마 일부 수정
</br>

- Network 모델에 `status`, `created_at`, `updated_at` 필드 추가
- UserBlock 모델 추가 
- Prisma에서 생성된 마이그레이션이 실제 DB와 충돌나서 수동 수정하였음..
 - Prisma 마이그레이션 충돌 해결을 위해 `resolve` 적용
- 현재 `migrate status` 기준, schema와 DB 상태 일치함