### PR TITLE
Bug(86): 커피챗 로직 및 버그 수정

### DIFF
--- a/prisma/migrations/20250730090351_add_coffeechat_id_to_message/migration.sql
+++ b/prisma/migrations/20250730090351_add_coffeechat_id_to_message/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `Message` ADD COLUMN `coffeechat_id` BIGINT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -337,6 +337,7 @@ model Message {
   detail_message String // 메시지 내용
   created_at     DateTime    @default(now()) // 전송 시간
   type           MessageType // 메시지 타입
+  coffeechat_id  BigInt? // 커피챗 메시지일 경우 커피챗 id
 
   // 관계
   chatRoom ChattingRoom @relation(fields: [chat_id], references: [id])

--- a/src/modules/coffeechat/coffeechat.controller.js
+++ b/src/modules/coffeechat/coffeechat.controller.js
@@ -23,6 +23,7 @@ export const coffeechatController = {
             const chattingRoomId = BigInt(req.params.chattingRoomId);
             const { receiver_id, title, scheduled_at, place } = req.body;
             const senderId = req.user.service_id;
+
             if (!chattingRoomId) {
                 throw new BadRequestError('chattingRoomId가 유효하지 않습니다.')
             }
@@ -42,13 +43,13 @@ export const coffeechatController = {
     },
     acceptCoffeechat: async (req, res, next) => {
         try {
-            const { chattingRoomId, coffeechatId } = req.params
+            const { chattingRoomId } = req.params
             const senderId = req.user.service_id
-
+            const { coffeechat_id } = req.body
             const result = await coffeechatService.acceptCoffeechat({
                 chattingRoomId,
-                coffeechatId,
                 senderId,
+                coffeechat_id
             })
 
             res.success({
@@ -62,13 +63,13 @@ export const coffeechatController = {
     },
     rejectCoffeechat: async (req, res, next) => {
         try {
-            const { chattingRoomId, coffeechatId } = req.params
+            const { chattingRoomId, } = req.params
             const senderId = req.user.service_id
-
+            const { coffeechat_id } = req.body
             const result = await coffeechatService.rejectCoffeechat({
                 chattingRoomId,
-                coffeechatId,
                 senderId,
+                coffeechat_id
             })
 
             res.success({
@@ -83,20 +84,19 @@ export const coffeechatController = {
     updateCoffeechat: async (req, res, next) => {
         try {
             const senderId = req.user.service_id
-            const { chattingRoomId, coffeechatId } = req.params
-            const { title, scheduled_at, place } = req.body
-
+            const { chattingRoomId } = req.params
+            const { title, scheduled_at, place, coffeechat_id } = req.body
             const result = await coffeechatService.updateCoffeechat({
                 chattingRoomId,
-                coffeechatId,
                 senderId,
                 title,
                 scheduled_at,
-                place
+                place,
+                coffeechat_id
             })
 
             res.success({
-                coce: 200,
+                code: 200,
                 message: '커피챗 요청을 수정했습니다.',
                 result
             })
@@ -106,13 +106,13 @@ export const coffeechatController = {
     },
     cancelCoffeechat: async (req, res, next) => {
         try {
-            const { chattingRoomId, coffeechatId } = req.params
+            const { chattingRoomId } = req.params
             const serviceId = req.user.service_id
-
+            const { coffeechat_id } = req.body
             const result = await coffeechatService.cancelCoffeechat({
                 chattingRoomId,
-                coffeechatId,
-                serviceId
+                serviceId,
+                coffeechat_id
             })
 
             res.success({

--- a/src/modules/coffeechat/coffeechat.routes.js
+++ b/src/modules/coffeechat/coffeechat.routes.js
@@ -230,7 +230,7 @@ router.post('/:chattingRoomId/coffeechats', isAuthenticated, validateChattingRoo
 
 /**
  * @swagger
- * /api/chatting-rooms/{chattingRoomId}/coffeechats/{coffeechatId}/accept:
+ * /api/chatting-rooms/{chattingRoomId}/coffeechats/accept:
  *   patch:
  *     summary: 커피챗 요청 수락
  *     description: 커피챗 요청을 수락하고 메시지를 전송합니다. PENDING 상태일 때만 수락할 수 있습니다.
@@ -243,12 +243,18 @@ router.post('/:chattingRoomId/coffeechats', isAuthenticated, validateChattingRoo
  *         description: 채팅방 ID
  *         schema:
  *           type: integer
- *       - in: path
- *         name: coffeechatId
- *         required: true
- *         description: 커피챗 ID
- *         schema:
- *           type: integer
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - coffeechat_id
+ *             properties:
+ *               coffeechat_id:
+ *                 type: integer
+ *                 example: 123
  *     responses:
  *       200:
  *         description: 커피챗 수락 성공
@@ -313,11 +319,11 @@ router.post('/:chattingRoomId/coffeechats', isAuthenticated, validateChattingRoo
  */
 
 // 커피챗 수락
-router.patch('/:chattingRoomId/coffeechats/:coffeechatId/accept', isAuthenticated, validateChattingRoomParticipant, coffeechatController.acceptCoffeechat)
+router.patch('/:chattingRoomId/coffeechats/accept', isAuthenticated, validateChattingRoomParticipant, coffeechatController.acceptCoffeechat)
 
 /**
  * @swagger
- * /api/chatting-rooms/{chattingRoomId}/coffeechats/{coffeechatId}/reject:
+ * /api/chatting-rooms/{chattingRoomId}/coffeechats/reject:
  *   patch:
  *     summary: 커피챗 요청 거절
  *     description: 커피챗 요청을 거절하고 SYSTEM 메시지를 전송합니다. PENDING 상태일 때만 거절할 수 있습니다.
@@ -330,12 +336,18 @@ router.patch('/:chattingRoomId/coffeechats/:coffeechatId/accept', isAuthenticate
  *         description: 채팅방 ID
  *         schema:
  *           type: integer
- *       - in: path
- *         name: coffeechatId
- *         required: true
- *         description: 커피챗 ID
- *         schema:
- *           type: integer
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - coffeechat_id
+ *             properties:
+ *               coffeechat_id:
+ *                 type: integer
+ *                 example: 123
  *     responses:
  *       200:
  *         description: 커피챗 거절 성공
@@ -408,11 +420,11 @@ router.patch('/:chattingRoomId/coffeechats/:coffeechatId/accept', isAuthenticate
  */
 
 // 커피챗 거절
-router.patch('/:chattingRoomId/coffeechats/:coffeechatId/reject', isAuthenticated, validateChattingRoomParticipant, coffeechatController.rejectCoffeechat)
+router.patch('/:chattingRoomId/coffeechats/reject', isAuthenticated, validateChattingRoomParticipant, coffeechatController.rejectCoffeechat)
 
 /**
  * @swagger
- * /api/chatting-rooms/{chattingRoomId}/coffeechats/{coffeechatId}/update:
+ * /api/chatting-rooms/{chattingRoomId}/coffeechats/update:
  *   patch:
  *     summary: 커피챗 요청 수정
  *     description: 커피챗 요청자만 커피챗의 제목, 시간, 장소를 수정할 수 있습니다.
@@ -425,12 +437,6 @@ router.patch('/:chattingRoomId/coffeechats/:coffeechatId/reject', isAuthenticate
  *         description: 채팅방 ID
  *         schema:
  *           type: integer
- *       - in: path
- *         name: coffeechatId
- *         required: true
- *         description: 커피챗 ID
- *         schema:
- *           type: integer
  *     requestBody:
  *       required: true
  *       content:
@@ -438,6 +444,9 @@ router.patch('/:chattingRoomId/coffeechats/:coffeechatId/reject', isAuthenticate
  *           schema:
  *             type: object
  *             properties:
+ *               coffeechat_id:
+ *                 type: string
+ *                 example: 123
  *               title:
  *                 type: string
  *                 example: 만나서 이야기 나눠보고 싶어요!
@@ -511,11 +520,11 @@ router.patch('/:chattingRoomId/coffeechats/:coffeechatId/reject', isAuthenticate
  */
 
 // 커피챗 수정
-router.patch('/:chattingRoomId/coffeechats/:coffeechatId/update', isAuthenticated, validateChattingRoomParticipant, coffeechatController.updateCoffeechat)
+router.patch('/:chattingRoomId/coffeechats/update', isAuthenticated, validateChattingRoomParticipant, coffeechatController.updateCoffeechat)
 
 /**
  * @swagger
- * /api/chatting-rooms/{chattingRoomId}/coffeechats/{coffeechatId}/cancel:
+ * /api/chatting-rooms/{chattingRoomId}/coffeechats/cancel:
  *   patch:
  *     summary: 커피챗 요청 취소
  *     description: 커피챗 요청자 또는 수신자만 커피챗 요청을 취소할 수 있습니다. 모든 상태에서 취소할 수 있습니다.
@@ -528,12 +537,18 @@ router.patch('/:chattingRoomId/coffeechats/:coffeechatId/update', isAuthenticate
  *         description: 채팅방 ID
  *         schema:
  *           type: integer
- *       - in: path
- *         name: coffeechatId
- *         required: true
- *         description: 커피챗 ID
- *         schema:
- *           type: integer
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - coffeechat_id
+ *             properties:
+ *               coffeechat_id:
+ *                 type: integer
+ *                 example: 123
  *     responses:
  *       200:
  *         description: 커피챗 요청 취소 성공
@@ -595,7 +610,7 @@ router.patch('/:chattingRoomId/coffeechats/:coffeechatId/update', isAuthenticate
  */
 
 // 커피챗 취소
-router.patch('/:chattingRoomId/coffeechats/:coffeechatId/cancel', isAuthenticated, coffeechatController.cancelCoffeechat)
+router.patch('/:chattingRoomId/coffeechats/cancel', isAuthenticated, coffeechatController.cancelCoffeechat)
 
 /**
  * @swagger

--- a/src/modules/coffeechat/coffeechat.service.js
+++ b/src/modules/coffeechat/coffeechat.service.js
@@ -60,7 +60,8 @@ const coffeechatService = {
                     chat_id: BigInt(chattingRoomId),
                     sender_id: BigInt(senderId),
                     detail_message: '커피챗 요청이 도착했습니다.',
-                    type: 'COFFEECHAT'
+                    type: 'COFFEECHAT',
+                    coffeechat_id: newCoffeeChat.id
                 }
             })
             console.log('메시지 생성 완료')
@@ -97,11 +98,11 @@ const coffeechatService = {
         }
     },
 
-    acceptCoffeechat: async ({ chattingRoomId, coffeechatId, senderId }) => {
+    acceptCoffeechat: async ({ chattingRoomId, coffeechat_id, senderId }) => {
 
         // 1. 커피챗 존재 확인
         const coffeechat = await prisma.coffeeChat.findUnique({
-            where: { id: BigInt(coffeechatId) }
+            where: { id: BigInt(coffeechat_id) }
         })
         if (!coffeechat) {
             throw new NotFoundError('존재하지 않는 커피챗 요청입니다.')
@@ -118,7 +119,7 @@ const coffeechatService = {
 
         // 3. 상태 업데이트
         await prisma.coffeeChat.update({
-            where: { id: BigInt(coffeechatId) },
+            where: { id: BigInt(coffeechat_id) },
             data: { status: 'ACCEPTED' }
         })
 
@@ -157,16 +158,16 @@ const coffeechatService = {
         }
 
         return {
-            coffeechat_id: Number(coffeechatId),
+            coffeechat_id: Number(coffeechat_id),
             status: 'ACCEPTED'
         }
     },
 
-    rejectCoffeechat: async ({ chattingRoomId, coffeechatId, senderId }) => {
+    rejectCoffeechat: async ({ chattingRoomId, coffeechat_id, senderId }) => {
 
         // 1. 커피챗 존재 확인
         const coffeechat = await prisma.coffeeChat.findUnique({
-            where: { id: BigInt(coffeechatId) }
+            where: { id: BigInt(coffeechat_id) }
         })
         if (!coffeechat) {
             throw new NotFoundError('존재하지 않는 커피챗 요청입니다.')
@@ -183,7 +184,7 @@ const coffeechatService = {
 
         // 3. 상태 업데이트
         await prisma.coffeeChat.update({
-            where: { id: BigInt(coffeechatId) },
+            where: { id: BigInt(coffeechat_id) },
             data: { status: 'REJECTED' }
         })
 
@@ -222,14 +223,14 @@ const coffeechatService = {
         }
 
         return {
-            coffeechat_id: Number(coffeechatId),
+            coffeechat_id: Number(coffeechat_id),
             status: 'REJECTED'
         }
     },
-    updateCoffeechat: async ({ chattingRoomId, coffeechatId, senderId, title, scheduled_at, place }) => {
+    updateCoffeechat: async ({ chattingRoomId, coffeechat_id, senderId, title, scheduled_at, place }) => {
 
         const coffeechat = await prisma.coffeeChat.findUnique({
-            where: { id: BigInt(coffeechatId) }
+            where: { id: BigInt(coffeechat_id) }
         })
         if (!coffeechat) {
             throw new NotFoundError('존재하지 않는 커피챗 요청입니다.')
@@ -239,7 +240,7 @@ const coffeechatService = {
         }
 
         const updated = await prisma.coffeeChat.update({
-            where: { id: BigInt(coffeechatId) },
+            where: { id: BigInt(coffeechat_id) },
             data: {
                 title,
                 scheduled_at: new Date(scheduled_at),
@@ -254,10 +255,10 @@ const coffeechatService = {
             place: updated.place
         }
     },
-    cancelCoffeechat: async ({ chattingRoomId, coffeechatId, serviceId }) => {
+    cancelCoffeechat: async ({ chattingRoomId, coffeechat_id, serviceId }) => {
 
         const coffeechat = await prisma.coffeeChat.findUnique({
-            where: { id: BigInt(coffeechatId) }
+            where: { id: BigInt(coffeechat_id) }
         })
         if (!coffeechat) {
             throw new NotFoundError('존재하지 않는 커피챗 요청입니다.')
@@ -273,7 +274,7 @@ const coffeechatService = {
 
         // 1. 상태 업데이트
         await prisma.coffeeChat.update({
-            where: { id: BigInt(coffeechatId) },
+            where: { id: BigInt(coffeechat_id) },
             data: { status: 'CANCELED' },
         })
 
@@ -314,7 +315,7 @@ const coffeechatService = {
         }
 
         return {
-            coffeechat_id: Number(coffeechatId),
+            coffeechat_id: Number(coffeechat_id),
             status: 'CANCELED',
         }
     },


### PR DESCRIPTION
## 🔎 작업 내용

- 커피챗 수락/거절/취소/수정에서 필요한 coffeechat_id를 Params로 받는 방식에서 body로 받는 방식으로 변경
- Message 테이블에서 coffeechat_id 컬럼 추가
- 커피챗 수락/거절/취소/수정 시 생성되는 메시지에 coffeechat_id 컬럼 값이 저장되도록 수정
- 채팅방 생성 후 첫 메시지 생성 시 Chat 테이블의 is_visible 값이 true로 변경되지 않던 버그 수정
- 채팅방 목록 조회 시 is_visible이 true인 채팅방만 조회하도록 수정
  <br/>

## ➕ 이슈 링크

- [bug/86-accept_coffeechat #86 ]
<br/>