### PR TITLE
feat(90): 유저의 구인/구직 상태 업데이트 api 수정

### DIFF
--- a/src/modules/mypage/mypage.controller.js
+++ b/src/modules/mypage/mypage.controller.js
@@ -57,28 +57,22 @@ class MypageController {
         }
     }
 
-    // PUT /api/mypage/:userId/recruiting_status 요청을 처리하여 사용자 서비스의 recruiting_status를 업데이트
+    // PUT /api/mypage/recruiting_status 요청을 처리하여 사용자 서비스의 recruiting_status를 업데이트
     static async updateRecruitingStatus(req, res, next) {
         try {
-            const { userId } = req.params
+            const serviceId = req.user.service_id
             const { recruiting_status } = req.body
-            const authenticatedUserId = req.user.service_id
 
-            // 1. 입력값 유효성 검사
-            if (!userId || isNaN(userId) || String(BigInt(userId)) !== userId) {
-                throw new BadRequestError({ field: 'userId', message: '유효한 사용자 ID가 필요합니다.' })
-            }
+            /* 1. 입력값 유효성 검사
+            if (!serviceId || isNaN(serviceId) || String(BigInt(serviceId)) !== serviceId) {
+                throw new BadRequestError({ field: 'serviceId', message: '유효한 사용자 ID가 필요합니다.' })
+            } */
             if (!recruiting_status || typeof recruiting_status !== 'string' || recruiting_status.trim() === '') {
                 throw new BadRequestError({ field: 'recruiting_status', message: '유효한 모집 상태 값이 필요합니다.' })
             }
 
-            // 2. 권한 확인: 요청된 userId와 인증된 ID 일치 여부
-            if (String(authenticatedUserId) !== String(userId)) {
-                throw new ForbiddenError({ message: '수정할 수 있는 권한이 없습니다.' })
-            }
-
             // 3. 서비스 호출
-            const result = await MypageService.updateRecruitingStatus(userId, recruiting_status)
+            const result = await MypageService.updateRecruitingStatus(serviceId, recruiting_status)
 
             return res.success({
                 code: 200,
@@ -86,6 +80,7 @@ class MypageController {
                 result: result,
             });
         } catch (error) {
+            console.error('유저의 구인/구직 상태 업데이트 중 오류:', error)
             next(error)
         }
     }

--- a/src/modules/mypage/mypage.model.js
+++ b/src/modules/mypage/mypage.model.js
@@ -116,7 +116,7 @@ class MypageModel {
             })
 
         } catch (error) {
-            console.error(`MypageModel - 사용자 ID ${userId}의 recruiting_status 업데이트 중 오류:`, error);
+            console.error(`MypageModel - 사용자 ID ${serviceId}의 recruiting_status 업데이트 중 오류:`, error);
             throw error;
         }
     }

--- a/src/modules/mypage/mypage.routes.js
+++ b/src/modules/mypage/mypage.routes.js
@@ -233,7 +233,7 @@ router.patch('/profile_pic', isAuthenticated, MypageController.updateProfilePict
 
 /**
  * @swagger
- * /api/mypage/{user_id}/recruiting_status:
+ * /api/mypage/recruiting_status/update:
  *   patch:
  *     summary: 유저의 현재 구인/구직 상태 업데이트
  *     description: 로그인된 사용자와 연결된 서비스의 recruiting_status 를 업데이트합니다.
@@ -241,14 +241,6 @@ router.patch('/profile_pic', isAuthenticated, MypageController.updateProfilePict
  *       - Mypage
  *     security:
  *       - cookieAuth: [] # 쿠키 기반 인증을 사용함을 나타냄
- *     parameters:
- *       - in: path
- *         name: user_id
- *         required: true
- *         schema:
- *           type: string
- *           format: int64
- *         description: recruiting_status를 업데이트할 사용자의 고유 ID
  *     requestBody:
  *       required: true
  *       content:
@@ -260,8 +252,8 @@ router.patch('/profile_pic', isAuthenticated, MypageController.updateProfilePict
  *             properties:
  *               recruiting_status:
  *                 type: string
- *                 enum: ['구직 중', '구인 중', '구인 협의 중', '네트워킹 환영', '해당 없음']
- *                 example: "구직 중"
+ *                 enum: ['현재 구직 중!', '현재 구인 중!', '구인 협의 중', '네트워킹 환영', '해당 없음']
+ *                 example: "현재 구직 중!"
  *     responses:
  *       200:
  *         description: 유저의 현재 구인/구직 상태 업데이트 성공
@@ -282,9 +274,6 @@ router.patch('/profile_pic', isAuthenticated, MypageController.updateProfilePict
  *                 result:
  *                   type: object
  *                   properties:
- *                     user_id:
- *                       type: string
- *                       example: "1234567890123456789"
  *                     service_id:
  *                       type: string
  *                       example: "9876543210987654321"
@@ -334,7 +323,7 @@ router.patch('/profile_pic', isAuthenticated, MypageController.updateProfilePict
  *             schema:
  *               $ref: '#/components/schemas/InternalServerError'
  */
-router.patch('/:userId/recruiting_status', isAuthenticated, MypageController.updateRecruitingStatus)
+router.patch('/recruiting_status/update', isAuthenticated, MypageController.updateRecruitingStatus)
 
 /**
  * @swagger

--- a/src/modules/mypage/mypage.service.js
+++ b/src/modules/mypage/mypage.service.js
@@ -60,16 +60,13 @@ class MypageService {
 
     /**
      * 서비스의 recruiting_status를 업데이트
-     * @param {string} userId  
+     * @param {string} serviceId  
      * @param {string} newStatus - 업데이트할 새로운 상태 값
      * @returns {Promise<Object>} 업데이트된 서비스 정보
-     * @throws {NotFoundError} 
-     * @throws {BadRequestError} 
-     * @throws {InternalServerError} 
      */
-    static async updateRecruitingStatus(userId, newStatus) {
+    static async updateRecruitingStatus(serviceId, newStatus) {
         // 허용되는 recruiting_status 값 목록 
-        const ALLOWED_STATUSES = ['구직 중', '구인 중', '구인 협의 중', '네트워킹 환영', '해당 없음']
+        const ALLOWED_STATUSES = ['현재 구직 중!', '현재 구인 중!', '구인 협의 중', '네트워킹 환영', '해당 없음']
 
         try {
             // 1. 유효성 검사: newStatus가 허용되는 값인지 확인
@@ -77,14 +74,8 @@ class MypageService {
                 throw new BadRequestError({ message: `'${newStatus}'은(는) 유효하지 않은 모집 상태 값입니다. 허용되는 값: ${ALLOWED_STATUSES.join(', ')}` })
             }
 
-            // 2. 사용자 존재 여부 확인
-            const existingUser = await MypageModel.findUserProfileById(BigInt(userId))
-            if (!existingUser) {
-                throw new NotFoundError('해당 사용자를 찾을 수 없습니다.')
-            }
-
             // 3. 모델 계층 호출하여 recruiting_status 업데이트
-            const updatedServiceResult = await MypageModel.updateRecruitingStatus(BigInt(userId), newStatus)
+            const updatedServiceResult = await MypageModel.updateRecruitingStatus(BigInt(serviceId), newStatus)
 
             // 연결된 서비스가 없어서 업데이트가 이루어지지 않은 경우
             if (!updatedServiceResult) {


### PR DESCRIPTION
## 🔎 작업 내용

- /api/mypage/recruiting_status/update
- 수정 내용: 기존 /api/mypage/{user_id}/recruiting_status 에서 user_id를 뺌

  <br/>

## 이미지 첨부
<img width="1061" height="968" alt="스크린샷 2025-07-31 135157" src="https://github.com/user-attachments/assets/fc65569c-38a8-400f-a38c-948c4b21d989" />


<br/>

## ➕ 이슈 링크

- [feature/90-mypage-recruiting-status #90]

<br/>