### PR TITLE
bug(94): 이력/활동 카드 조회 로직 수정

### DIFF
--- a/src/modules/cards/cards.routes.js
+++ b/src/modules/cards/cards.routes.js
@@ -74,7 +74,7 @@ const router = express.Router()
  */
 
 // 이력/활동 카드 등록
-router.post('/', cardsController.createCard)
+router.post('/', isAuthenticated, cardsController.createCard)
 
 /**
  * @swagger
@@ -95,7 +95,7 @@ router.post('/', cardsController.createCard)
  *         schema:
  *           type: string
  *         required: false
- *         description: "활동 지역 ID (high_area_id)"
+ *         description: "활동 지역"
  *       - in: query
  *         name: status
  *         schema:
@@ -183,7 +183,7 @@ router.post('/', cardsController.createCard)
  */
 
 // 이력/활동 카드 스와이프 조회
-router.get('/swipe', cardsController.getFilteredCards)
+router.get('/swipe', isAuthenticated, cardsController.getFilteredCards)
 
 /**
  * @swagger
@@ -203,9 +203,9 @@ router.get('/swipe', cardsController.getFilteredCards)
  *       - in: query
  *         name: area
  *         schema:
- *           type: integer
+ *           type: string
  *         required: false
- *         description: "활동 지역 ID (예시: 1)"
+ *         description: "활동 지역 (예시: 서울)"
  *       - in: query
  *         name: status
  *         schema:
@@ -272,7 +272,7 @@ router.get('/swipe', cardsController.getFilteredCards)
  *                   message: 서버에 오류가 발생하였습니다.
  */
 
-router.get('/grid', cardsController.getCardgrid)
+router.get('/grid', isAuthenticated, cardsController.getCardgrid)
 
 /**
  * @swagger
@@ -358,6 +358,6 @@ router.get('/grid', cardsController.getCardgrid)
  */
 
 // 이력/활동 카드 상세 조회
-router.get('/:card_id', cardsController.getCardById)
+router.get('/:card_id', isAuthenticated, cardsController.getCardById)
 
 export default router

--- a/src/modules/cards/cards.service.js
+++ b/src/modules/cards/cards.service.js
@@ -105,7 +105,7 @@ const cardsService = {
             writer: {
                 id: card.service.id,
                 name: card.service.name,
-                sector: card.service.sector,
+                sector: card.service.low_sector,
                 profile_img_url: card.service.profile_img,
             },
         }
@@ -133,7 +133,9 @@ const cardsService = {
                 whereClause.service = {
                     userAreas: {
                         some: {
-                            high_area_id: parseInt(area),
+                            high_area: {
+                                equals: area,
+                            }
                         },
                     },
                 }
@@ -210,7 +212,7 @@ const cardsService = {
                     service_id: { in: serviceIds },
                     ...(hope_job && {
                         service: {
-                            sector: {
+                            low_sector: {
                                 contains: hope_job,
                             },
                         },
@@ -232,7 +234,7 @@ const cardsService = {
             const serviceIdToSector = {}
             userDBs.forEach((udb) => {
                 serviceIdToSector[udb.service_id] =
-                    udb.service?.sector || '직무 미입력'
+                    udb.service?.low_sector || '직무 미입력'
             })
 
             // 7. 최종 필터링 + 포맷팅
@@ -273,7 +275,11 @@ const cardsService = {
             if (area) {
                 whereClause.service = {
                     userAreas: {
-                        some: { high_area_id: parseInt(area) },
+                        some: {
+                            high_area: {
+                                equals: area,
+                            }
+                        },
                     },
                 }
             }
@@ -330,7 +336,7 @@ const cardsService = {
                     service_id: { in: serviceIds },
                     ...(hope_job && {
                         service: {
-                            sector: {
+                            low_sector: {
                                 contains: hope_job,
                             },
                         },


### PR DESCRIPTION
## 🔎 작업 내용

- 이력/활동 카드 조회에서 low_sector를 sector로 불러오고 있던 버그 수정
- 이력/활동 카드 필터링에서 지역 번호로 받는 것을 지역명으로 받도록 수정

  <br/>

## ➕ 이슈 링크

- [bug/94-get_activity_cards #94 ]

<br/>