### PR TITLE
Bug(108): 채팅 및 커피챗 로직 수정

### DIFF
--- a/prisma/migrations/20250801062618_add_sender_name_to_message/migration.sql
+++ b/prisma/migrations/20250801062618_add_sender_name_to_message/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `Message` ADD COLUMN `sender_name` VARCHAR(50) NOT NULL DEFAULT '알 수 없음';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -335,7 +335,7 @@ model Message {
   id             BigInt      @id @default(autoincrement()) // 메시지 ID
   chat_id        BigInt // 채팅방 ID (FK)
   sender_id      BigInt // 송신자 서비스 ID (FK)
-  sender_name    String      @db.VarChar(50) // 송신자 이름
+  sender_name    String      @default("알 수 없음") @db.VarChar(50) // 송신자 이름
   detail_message String // 메시지 내용
   created_at     DateTime    @default(now()) // 전송 시간
   type           MessageType // 메시지 타입

--- a/src/app.js
+++ b/src/app.js
@@ -17,16 +17,7 @@ app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec))
 
 // 공통 미들웨어
 app.use(cors({
-    // origin: 'http://172.100.13.155:5173',
-    // origin: [
-    //     'http://localhost:5173',
-    //     'http://localhost:3001',
-    //     'http://172.100.13.155:5173'
-    // ],
-    origin: function (origin, callback) {
-        //모든 origin 허용
-        callback(null, origin)
-    },
+    origin: 'http://localhost:5173',
     credentials: true
 }))
 app.use(morgan('dev'))

--- a/src/modules/cards/cards.routes.js
+++ b/src/modules/cards/cards.routes.js
@@ -74,7 +74,7 @@ const router = express.Router()
  */
 
 // 이력/활동 카드 등록
-router.post('/', isAuthenticated, cardsController.createCard)
+router.post('/', cardsController.createCard)
 
 /**
  * @swagger

--- a/src/modules/chatting/chatting.model.js
+++ b/src/modules/chatting/chatting.model.js
@@ -2,7 +2,7 @@ import { PrismaClient } from "@prisma/client";
 const prisma = new PrismaClient()
 
 const chattingModel = {
-    createMessage: async ({ chattingRoomId, senderId, detail_message, type }) => {
+    createMessage: async ({ chattingRoomId, senderId, detail_message, type, sender_name }) => {
         try {
             return await prisma.message.create({
                 data: {
@@ -10,6 +10,7 @@ const chattingModel = {
                     sender_id: BigInt(senderId),
                     detail_message,
                     type,
+                    sender_name,
                 }
             })
         } catch (error) {

--- a/src/modules/chatting/chatting.service.js
+++ b/src/modules/chatting/chatting.service.js
@@ -96,6 +96,16 @@ const chattingService = {
             throw new BadRequestError('이 채팅방의 참여자가 아닙니다.')
         }
 
+        // 사용자 이름 조회
+        const senderService = await prisma.service.findUnique({
+            where: { id: BigInt(senderId) },
+            select: { name: true }
+        })
+
+        if (!senderService) {
+            throw new BadRequestError('송신자 정보가 존재하지 않습니다.')
+        }
+
         // 만약 is_visible이 false라면 true로 변경 (첫 메시지일 경우)
         if (!chattingRoom.is_visible) {
             await prisma.chattingRoom.update({
@@ -109,6 +119,7 @@ const chattingService = {
             senderId,
             detail_message,
             type,
+            sender_name: senderService.name
 
         })
 

--- a/src/modules/coffeechat/coffeechat.service.js
+++ b/src/modules/coffeechat/coffeechat.service.js
@@ -57,13 +57,18 @@ const coffeechatService = {
             });
             console.log("✅ 커피챗 생성 완료", newCoffeeChat);
 
+            const senderService = await tx.service.findUnique({
+                where: { id: BigInt(senderId) },
+                select: { name: true }
+            })
 
             // 2. 메시지 생성 및 Redis 캐시 (type: COFFEECHAT)
             const newMessage = await tx.message.create({
                 data: {
                     chat_id: BigInt(chattingRoomId),
                     sender_id: BigInt(senderId),
-                    detail_message: '님이 커피챗 요청을 수락하였습니다!',
+                    sender_name: senderService.name,
+                    detail_message: '님이 커피챗 요청을 요청하였습니다!',
                     type: 'COFFEECHAT',
                     coffeechat_id: newCoffeeChat.id
                 }
@@ -111,12 +116,9 @@ const coffeechatService = {
         const safeMessage = convertBigIntsToNumbers(message);
 
         try {
-            const senderService = await tx.service.findUnique({
-                where: { id: BigInt(senderId) },
-                select: { name: true }
-            })
+
             console.log("📤 emit 실행 준비 완료");
-            io.to(`chat:${chattingRoomId}`).emit('receiveMessage', { ...safeMessage, name: senderService.name });
+            io.to(`chat:${chattingRoomId}`).emit('receiveMessage', safeMessage);
             console.log("📤 emit 실행됨: ", safeMessage);
         } catch (error) {
             console.error("❌ 소켓 emit 실패", error);
@@ -165,6 +167,7 @@ const coffeechatService = {
             data: {
                 chat_id: BigInt(chattingRoomId),
                 sender_id: BigInt(senderId),
+                sender_name: senderService.name,
                 detail_message: `${senderService.name}님이 커피챗 요청을 수락하였습니다!`,
                 type: 'COFFEECHAT',
                 coffeechat_id: BigInt(coffeechat_id)
@@ -231,7 +234,8 @@ const coffeechatService = {
             data: {
                 chat_id: BigInt(chattingRoomId),
                 sender_id: BigInt(senderId),
-                detail_message: `${senderService.name}님이 커피챗 요청을 거절하였습니다!`,
+                sender_name: senderService.name,
+                detail_message: '님이 커피챗 요청을 거절하였습니다!',
                 type: 'COFFEECHAT',
                 coffeechat_id: BigInt(coffeechat_id)
             }
@@ -292,7 +296,8 @@ const coffeechatService = {
             data: {
                 chat_id: BigInt(chattingRoomId),
                 sender_id: BigInt(senderId),
-                detail_message: `${senderService.name}님이 커피챗 요청을 수정하였습니다.`,
+                sender_name: senderService.name,
+                detail_message: `님이 커피챗 요청을 수정하였습니다.`,
                 type: 'COFFEECHAT',
                 coffeechat_id: BigInt(coffeechat_id)
             }
@@ -357,7 +362,8 @@ const coffeechatService = {
             data: {
                 chat_id: BigInt(chattingRoomId),
                 sender_id: BigInt(serviceId),
-                detail_message: `${senderService.name}님이 커피챗 요청을 취소하였습니다.`,
+                sender_name: senderService.name,
+                detail_message: `님이 커피챗 요청을 취소하였습니다.`,
                 type: 'SYSTEM',
                 coffeechat_id: BigInt(coffeechat_id)
             },


### PR DESCRIPTION
## 🔎 작업 내용

- Message 테이블에 sender_name 컬럼 추가
- 메시지 및 커피챗 메시지를 보낼 때 sender_name을 같이 보내도록 수정
- cors origin 수정
- 이력/활동 카드 등록 API 로그인 검사 안하도록 수정

<br/>

## ➕ 이슈 링크

- [bug/108-message #108 ]
<br/>